### PR TITLE
rt2500 staking changes

### DIFF
--- a/builders/pallets-precompiles/pallets/staking.md
+++ b/builders/pallets-precompiles/pallets/staking.md
@@ -56,7 +56,6 @@ DPOS共识系统利用[平行链质押pallet](https://github.com/moonbeam-founda
 - **cancelCandidateBondLess**() - 取消一个待定中的已计划请求，以减少候选人（收集人）自身绑定数量
 - **cancelDelegationRequest**(candidate) -  取消提供候选人（收集人）的地址的任何待定中委托的请求
 - **cancelLeaveCandidates**(candidateCount) - 取消一个候选人（收集人）的待定中的已计划的请求，就目前在池中候选人的数量，以离开该池
-- **cancelLeaveDelegators**() - *运行时1800弃用* 取消一个待定中的已计划的请求以离开委托人池。可以使用[批量处理方法](/builders/pallets-precompiles/pallets/utility/#using-the-batch-extrinsics){target=_blank}来打包多个`cancelDelegationRequest`请求
 - **candidateBondMore**(more) - 请求增加有具体数量的候选人（收集人）自身绑定量
 - **delegate**(candidate, amount, candidateDelegationCount, delegationCount) - 请求添加针对特定候选人（收集人）的给定数量的委托并将自动复合的奖励百分比设置为`0`。如果调用者不是委托人，此函数添加其至委托人池。如果调用者已经是委托人，那么此函数调整其委托数量
 - **delegateWithAutoCompound**(candidate, amount, autoCompound, candidateDelegationCount, candidateAutoCompoundingDelegationCount, delegationCount) - 委托一个收集人候选人并用`amount`，一个0-100之间的整数（无小数）设置自动复合奖励百分比。如果调用者不是委托人，则此函数将它们添加到委托人集合中。如果调用者已经是委托人，则调整他们的委托数量。
@@ -64,14 +63,12 @@ DPOS共识系统利用[平行链质押pallet](https://github.com/moonbeam-founda
 - **executeCandidateBondLess**(candidate) - 执行任何已计划的到期请求，以减少候选人（收集人）自身绑定量
 - **executeDelegationRequest**(delegator, candidate) - 为提供候选人（收集人）的地址的特定委托人执行任何已计划的到期委托请求
 - **executeLeaveCandidates**(candidate, candidateDelegationCount) - 执行任何已计划的到期请求，以离开候选人（收集人）池
-- **executeLeaveDelegators**(delegator, delegationCount) - *运行时1800弃用* 执行已计划的到期请求，以离开委托人池并撤销所有委托。可以使用[批量处理方法](/builders/pallets-precompiles/pallets/utility/#using-the-batch-extrinsics){target=_blank}来打包多个`executeDelegationRequest`请求
 - **goOffline**() - 无需解绑，允许收集人暂时离开池
 - **goOnline**() - 在之前调用`goOffline()`之后，允许收集人重新加入池
 - **joinCandidates**(bond, candidateCount) - 请求在特定绑定量并提供现有候选人（收集人）数量的情况下加入收集人池
 - **scheduleCandidateBondLess**(less) - 计划一个请求，以特定数量来减少候选人（收集人）自身绑定。这里有[退出生效期](#exit-delays)，即在您通过`executeCandidateBondLess` extrinsic执行请求之前必须等待
 - **scheduleDelegatorBondLess**(candidate, less) - 为委托人针对候选人（收集人）绑定更少的量计划一个请求。这里有[退出生效期](#exit-delays)，即您通过`executeDelegationRequest` extrinsic执行请求之前必须等待
 - **scheduleLeaveCandidates**(candidateCount) - 为候选人（收集人）自行从池移出计划一个请求。这里有[退出生效期](#exit-delays)，即您通过`executeLeaveCandidates` extrinsic执行请求之前必须等待
-- **scheduleLeaveDelegators**() - *运行时1800弃用* 计划一个请求，以离开委托人池并撤销所有正在进行的委托。可以使用[批量处理方法](/builders/pallets-precompiles/pallets/utility/#using-the-batch-extrinsics){target=_blank}来打包多个`scheduleRevokeDelegation`请求
 - **scheduleRevokeDelegation**(collator) - 计划一个请求，以撤销一个给定候选人（收集人）地址的委托。这里有[退出生效期](#exit-delays)，即您通过`executeDelegationRequest` extrinsic执行请求之前必须等待
 - **setAutoCompound**(candidate, value, candidateAutoCompoundingDelegationCountHint, delegationCountHint) - 给定`value`，一个0-100之间的整数（无小数），设置现有委托自动复合的奖励百分比
 - **setBlocksPerRound**(new) - 设定每个轮次的区块。如果`new`值少于目前轮次的长度，将立即转换下一个区块
@@ -128,7 +125,7 @@ DPOS共识系统利用[平行链质押pallet](https://github.com/moonbeam-founda
 - **minCandidateStk**() - 返回成为候选人（收集人）所需的最低质押
 - **minCollatorStk**() - *运行时2400弃用* - 返回成为收集人活跃集中所需的最低质押
 - **minDelegation**() - 返回最低委托数
-- **minDelegatorStk**() - 返回账户成为委托人的最低质押
+- **minDelegatorStk**() - *运行时2500弃用* - 返回账户成为委托人的最低质押
 - **minSelectedCandidates**() - 返回每个轮次在活跃集中选出的收集人（收集人）的最低数量
 - **revokeDelegationDelay**() - 在已计划的撤销委托的请求可以被执行之前，返回必须等待的轮次数
 - **rewardPaymentDelay**() - 在区块生产者被奖励之后，返回必须等待的轮次数

--- a/builders/pallets-precompiles/precompiles/staking.md
+++ b/builders/pallets-precompiles/precompiles/staking.md
@@ -110,7 +110,7 @@ Solidity接口包含以下的函数：
  - **getDelegatorTotalStaked**(*address* delegator) —— 只读函数，返回给定委托人的总质押金额，与候选人无关。使用质押pallet 的[`delegatorState`](/builders/pallets-precompiles/pallets/staking/#:~:text=delegatorState(AccountId20)){target=_blank}函数
  - **getCandidateTotalCounted**(*address* candidate) —— 只读函数，返回给定候选人的质押总额。使用质押pallet的[`candidateInfo`](/builders/pallets-precompiles/pallets/staking/#:~:text=candidateInfo(AccountId20)){target=_blank}函数
 
-从运行时1800开始，以下方法已被**弃用**：
+ 从运行时1800开始，以下方法已被**弃用**，并且从运行时2500开始，已被删除：
 
  - **scheduleLeaveDelegators**() —— 发起离开委托人集并撤回所有进行中的委托的请求。发起请求并不会自动执行，需要等待[退出延迟](#exit-delays)，您可以通过`executeLeaveDelegators`函数执行请求。可以使用[批量处理方法](/builders/pallets-precompiles/pallets/utility/#using-the-batch-extrinsics){target=_blank}来打包多个`scheduleLeaveDelegators`请求
  - **executeLeaveDelegators**(*address* delegator, *uint256* delegatorDelegationCount) —— 执行离开委托人集和撤回所有委托的可用请求。可以使用[批量处理方法](/builders/pallets-precompiles/pallets/utility/#using-the-batch-extrinsics){target=_blank}来打包多个`executeLeaveDelegators`请求

--- a/builders/pallets-precompiles/precompiles/staking.md
+++ b/builders/pallets-precompiles/precompiles/staking.md
@@ -78,7 +78,7 @@ Solidity接口包含以下的函数：
  - **awardedPoints**(*uint32* round, *address* candidate) —— 只读函数，返回在给定轮次中授予给给定收集人的总分。如果返回`0`，可能是因为没有生成区块或者该轮的存储已被删除。使用质押Pallet的[`points`](/builders/pallets-precompiles/pallets/staking/#:~:text=awardedPts(u32, AccountId20)){target=_blank}函数
  - **delegationAmount**(*address* delegator, *address* candidate) —— 只读函数，返回给定委托人为支持给定候选人而委托的金额。使用质押pallet的[`delegatorState`](/builders/pallets-precompiles/pallets/staking/#:~:text=delegatorState(AccountId20)){target=_blank}函数
  - **isInTopDelegations**(*address* delegator, *address* candidate) —— 只读函数，它返回一个布尔值，标示给定的委托人是否在给定候选人的最高委托中。使用质押pallet的[`topDelegations`](/builders/pallets-precompiles/pallets/staking/#:~:text=topDelegations(AccountId20)){target=_blank}函数
- - **minDelegation**() —— 获取最小委托数量的只读函数。使用质押Pallet的`minDelegation`](/builders/pallets-precompiles/pallets/staking/#:~:text=minDelegation()){target=_blank}函数
+ - **minDelegation**() —— 获取最小委托数量的只读函数。使用质押Pallet的[`minDelegation`](/builders/pallets-precompiles/pallets/staking/#:~:text=minDelegation()){target=_blank}函数
  - **candidateCount**() —— 获取当前候选收集人数量的只读函数。使用质押Pallet的[`candidatePool`](/builders/pallets-precompiles/pallets/staking/#:~:text=candidatePool()){target=_blank}函数
  - **round**() —— 返回当前轮数的只读函数。使用质押Pallet的[`round`](/builders/pallets-precompiles/pallets/staking/#:~:text=round()){target=_blank}函数
  - **candidateDelegationCount**(*address* candidate) —— 返回指定候选收集人地址的委托数量的只读函数。使用质押Pallet的[`candidateInfo`](/builders/pallets-precompiles/pallets/staking/#:~:text=candidateInfo(AccountId20)){target=_blank}函数
@@ -132,7 +132,7 @@ Solidity接口包含以下的函数：
 
 ## 与Solidity接口进行交互 {: #interact-with-solidity-interface }
 
-### 查看先决条件 {: #checking-prerequisites } 
+### 查看先决条件 {: #checking-prerequisites }
 
 以下的示例将会在Moonbase Alpha上演示。同样适用于其他网络，包括Moonbeam和Moonriver。
 
@@ -157,7 +157,7 @@ Solidity接口包含以下的函数：
 
 ![Compiling StakingInteface.sol](/images/builders/pallets-precompiles/precompiles/staking/staking-2.png)
 
-### 读取合约 {: #access-the-contract } 
+### 读取合约 {: #access-the-contract }
 
 1. 点击Remix界面中**Compile**标签正下方的**Deploy and Run**标签。注意：我们现在并不是在这里部署合约，而是使用先前部署的预编译合约
 2. 确认已选取**ENVIRONMENT**下拉菜单中的**Injected Provider - Metamask**


### PR DESCRIPTION
### Description/Original PRs

- Deprecate `MinDelegatorStk` constant
- Remove previously deprecated staking functions:
  - schedule_leave_delegators
  - execute_leave_delegators
  - cancel_leave_delegators

Original PR: https://github.com/moonbeam-foundation/moonbeam-docs/pull/741
