### PR TITLE
remove blockscout

### DIFF
--- a/.snippets/text/explorers/explorers.md
+++ b/.snippets/text/explorers/explorers.md
@@ -1,29 +1,25 @@
 === "Moonbeam"
-    | 区块浏览器  |   类型    |                                                                           URL                                                                            |
-    |:-----------:|:---------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |  Moonscan   |    EVM    |                                      [https://moonbeam.moonscan.io/](https://moonbeam.moonscan.io/){target=_blank}                                       |
-    | Blockscout  |    EVM    |                               [https://blockscout.moonbeam.network/](https://blockscout.moonbeam.network/){target=_blank}                                |
-    | Expedition  |    EVM    |            [https://moonbeam-explorer.netlify.app/?network=Moonbeam](https://moonbeam-explorer.netlify.app/?network=Moonbeam){target=_blank}             |
-    |   Subscan   | Substrate |                                       [https://moonbeam.subscan.io/](https://moonbeam.subscan.io/){target=_blank}                                        |
+    | 区块浏览器  |   类型    |                                                                 URL                                                                  |
+    |:-----------:|:---------:|:------------------------------------------------------------------------------------------------------------------------------------:|
+    |  Moonscan   |    EVM    |                            [https://moonbeam.moonscan.io/](https://moonbeam.moonscan.io/){target=_blank}                             |
+    | Expedition  |    EVM    |  [https://moonbeam-explorer.netlify.app/?network=Moonbeam](https://moonbeam-explorer.netlify.app/?network=Moonbeam){target=_blank}   |
+    |   Subscan   | Substrate |                             [https://moonbeam.subscan.io/](https://moonbeam.subscan.io/){target=_blank}                              |
     | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank} |
 
-
 === "Moonriver"
-    | 区块浏览器  |   类型    |                                                                            URL                                                                            |
-    |:-----------:|:---------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |  Moonscan   |    EVM    |                                      [https://moonriver.moonscan.io/](https://moonriver.moonscan.io/){target=_blank}                                      |
-    | Blockscout  |    EVM    |                      [https://blockscout.moonriver.moonbeam.network/](https://blockscout.moonriver.moonbeam.network/){target=_blank}                      |
-    | Expedition  |    EVM    |            [https://moonbeam-explorer.netlify.app/?network=Moonriver](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}            |
-    |   Subscan   | Substrate |                                       [https://moonriver.subscan.io/](https://moonriver.subscan.io/){target=_blank}                                       |
+    | 区块浏览器  |   类型    |                                                                      URL                                                                       |
+    |:-----------:|:---------:|:----------------------------------------------------------------------------------------------------------------------------------------------:|
+    |  Moonscan   |    EVM    |                                [https://moonriver.moonscan.io/](https://moonriver.moonscan.io/){target=_blank}                                 |
+    | Expedition  |    EVM    |      [https://moonbeam-explorer.netlify.app/?network=Moonriver](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}       |
+    |   Subscan   | Substrate |                                 [https://moonriver.subscan.io/](https://moonriver.subscan.io/){target=_blank}                                  |
     | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/explorer){target=_blank} |
 
 === "Moonbase Alpha"
-    | 区块浏览器  |   类型    |                                                                         URL                                                                         |
-    |:-----------:|:---------:|:---------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |  Moonscan   |    EVM    |                                    [https://moonbase.moonscan.io/](https://moonbase.moonscan.io/){target=_blank}                                    |
-    | Blockscout  |    EVM    |            [https://moonbase-blockscout.testnet.moonbeam.network/](https://moonbase-blockscout.testnet.moonbeam.network/){target=_blank}            |
-    | Expedition  |    EVM    |     [https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}     |
-    |   Subscan   | Substrate |                                     [https://moonbase.subscan.io/](https://moonbase.subscan.io/){target=_blank}                                     |
+    | 区块浏览器  |   类型    |                                                                      URL                                                                      |
+    |:-----------:|:---------:|:---------------------------------------------------------------------------------------------------------------------------------------------:|
+    |  Moonscan   |    EVM    |                                 [https://moonbase.moonscan.io/](https://moonbase.moonscan.io/){target=_blank}                                 |
+    | Expedition  |    EVM    |  [https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}  |
+    |   Subscan   | Substrate |                                  [https://moonbase.subscan.io/](https://moonbase.subscan.io/){target=_blank}                                  |
     | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank} |
 
 === "Moonbeam开发节点"

--- a/builders/build/eth-api/debug-trace.md
+++ b/builders/build/eth-api/debug-trace.md
@@ -7,7 +7,7 @@ description: 学习如何使用Geth的Debug和Txpool API，以及OpenEthereum的
 
 ## 概览 {: #introduction }
 
-Geth的`debug`与`txpool` API，以及OpenEthereum的`trace`模块均提供非标准的RPC方法，用于获取更多关于交易处理的详细信息。作为Moonbeam为开发者提供无缝以太坊开发体验目标的其中一部分，Moonbeam支持部分非标准RPC方法。支持这些RPC方法是个重要的里程碑，因为如[The Graph](https://thegraph.com/){target=_blank}或[Blockscout](https://docs.blockscout.com/){target=_blank}等项目仰赖这些方法检索区块链数据。
+Geth的`debug`与`txpool` API，以及OpenEthereum的`trace`模块均提供非标准的RPC方法，用于获取更多关于交易处理的详细信息。作为Moonbeam为开发者提供无缝以太坊开发体验目标的其中一部分，Moonbeam支持部分非标准RPC方法。支持这些RPC方法是个重要的里程碑，因为如[The Graph](https://thegraph.com/){target=_blank}等项目仰赖这些方法检索区块链数据。
 
 要查看追踪RPC提供者，请查看[网络端点](/builders/get-started/endpoints#tracing-providers){target=_blank}页面。
 

--- a/builders/build/eth-api/verify-contracts/block-explorers.md
+++ b/builders/build/eth-api/verify-contracts/block-explorers.md
@@ -30,17 +30,14 @@ description: 学习如何使用区块浏览器在Moonbeam网络上验证智能�
 为验证合约，您将需要收集合约编译器和部署细节的相关信息以保证验证能够顺利进行。
 
 1. 记录用于编译和部署合约的Solidity编译器版本。通常Solidity编译器的版本会在使用的部署工具中提及和描述
-
 2. 记录任何在Solidity开源文件开头使用的任何SPDX证照识别码
 
     ```solidity
     // SPDX-License-Identifier: MIT
     ```
-    
+
 3. （可选） 如果在编译过程中开启过Optimization，记录Optimization运行系数的数值
-
 4. （可选）如果合约构造方法接受参数，记录构造函数的[ABI编码形式](https://docs.soliditylang.org/en/develop/abi-spec.html)
-
 5. 在部署后，记录智能合约部署的合约地址。合约的部署地址可以通过使用Truffle、Hardhat或以太坊库等基于命令行的开发工具，在控制台输出中获得，也可以通过Remix IDE等工具中在GUI中复制获得
 
 ![Example Compiler Options in Remix IDE](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-1.png)
@@ -56,63 +53,27 @@ description: 学习如何使用区块浏览器在Moonbeam网络上验证智能�
 在Moonscan中跟随以下步骤以验证合约：
 
 1. 在Moonscan中导向至[Verify & Publish Contract Source Code](https://moonbase.moonscan.io/verifyContract)页面
-
 2. 在第一个输入框中填入`0x`开头的合约部署地址
-
 3. 选择编译器类型。在此`Incrementer.sol`示例中，选取**Solidity（Single file）**
-
 4. 选取完编译器类型后，选取用于部署合约的编译器版本。如果所使用的编译器版本为nightly commit，取消输入框下的勾选框，即选取nightly版本
-
 5. 选取所使用的开源证照。在此`Incrementer.sol`示例中，选取**MIT License（MIT）**。如果未使用任何证照，选取**No License（None）**
-
 6. 在表格底下点击**Continue**按钮以进入下个页面
 
-    ![First Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-3.png)
+![First Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-3.png)
 
 在第二个页面，**Contract Address**、**Compiler**和**Constructor Arguments**的输入框应该都已自动填写完毕，您只需填写以下信息：
 
 1. 在文字输入框中粘贴复制的合约内容
-
 2. （可选）如果在编译时曾经开启**Optimization**，则选取**Yes**，并在**Misc Settings/Runs (Optmizer)**下输入运行次数
-
 3. （可选）如果曾使用合约库及其地址，则新增合约库和地址
-
 4. （可选）勾选任何可应用至您的合约的输入框，并根据指示填写信息
-
 5. 在页面底下点击CAPTCHA和**Verify and Publish**按钮以确认信息并开始验证
 
-   ![Second Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-4.png)
+![Second Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-4.png)
 
 经过一段时间后，验证的结果将会显示在浏览器上，成功结果的页面将会显示合约的ABI编码构造函数、合约名称、字节码和ABI。
 
-​    ![Result Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-5.png)
-
-### BlockScout {: #blockscout }
-
-在[BlockScout](https://moonbase-blockscout.testnet.moonbeam.network/)上通过搜寻地址导向至指定网络的合约页面，并在**Code**标签下点击**Verify & Publish**按钮
-
-​    ![BlockScout Verify Button](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-6.png)
-
-在验证页面，合约地址将会被自动填写，您只需输入以下信息：
-
-1. 输入合约名称，这必须与合约定义上的名称相同。在本示例中，合约名称为`Incrementer`
-
-2. 填写**Compiler**、**EVM Version**和**Optimization**输入框（如果Optimization在编译时曾被开启）
-
-3. 复制Solidity智能合约的完整内容并粘贴至文字输入框
-
-4. （可选）将**Try to fetch constructor arguments automatically**切换至**Yes**，即自动获取构造函数，或是在合约构造函数接受参数的情况下手动输入ABI编码的构造函数argument
-
-5. （可选）如果曾使用合约库及其地址，则新增合约库和地址
-
-6. 在所有信息填写完毕后点击页面下方的**Verify & Publish**按钮
-
-![BlockScout Verify Page](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-7.png)
-
-经过一段时间后，如果验证完全成功，浏览器将会回到合约的**Code**页面，显示合约的相关信息，包含构造函数ABI编码、合约名称、字节面、ABI和源代码。合约页面将同时拥有两个新的标签，**Read Contract**和**Write Contract**，方便用户阅读和直接撰写合约。
-
-​    ![BlockScout Result Page](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-8.png)
-
+​![Result Page Screenshot](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-5.png)
 
 ## 智能合约扁平化 {: #smart-contract-flattening }
 
@@ -128,6 +89,6 @@ description: 学习如何使用区块浏览器在Moonbeam网络上验证智能�
 
 在**Compiler Type**（上述示例中的第三个步骤）选取**Solidity (Multi-part files)**。在下个页面，选取并上传所有组成其智能合约的不同Solidity文件，包含嵌入依赖项的合约文件。
 
- ![Moonscan Multifile Page](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-9.png)
+![Moonscan Multifile Page](/images/builders/build/eth-api/verify-contracts/block-explorers/verify-contract-6.png)
 
 除此之外，其余验证过程与在Moonscan上验证单一文件合约的过程相同。

--- a/builders/get-started/explorers.md
+++ b/builders/get-started/explorers.md
@@ -29,7 +29,7 @@ Moonscan其他功能如下：
  - [Token授权](https://moonscan.io/tokenapprovalchecker){target=_blank}，您可以查看和撤销任何之前的Token授权
  - [添加Token信息](/builders/get-started/token-profile/){target=_blank}，并为部署到基于Moonbeam的网络的ERC-20、ERC-721和ERC-1155创建资料页面。资料页面可以包括您的项目连接、社交媒体、价格数据和与代币有关的其他信息
 
-![Moonriver Moonscan](/images/builders/get-started/explorers/explorers-1.png)
+![Moonbeam Moonscan](/images/builders/get-started/explorers/explorers-1.png)
 
 ### Expedition {: #expedition }
 
@@ -47,15 +47,15 @@ Moonscan其他功能如下：
 
 ### Subscan {: #subscan }
 
-[Subscan](https://moonbeam.subscan.io/){target=_blank} 是Moonbeam主要的Substrate API区块浏览器，它能够解析标准或自定义模块。举例而言，这个功能对展示关于质押、治理和EVM pallet（或是模块）非常有帮助。所有代码都是开源的，并且可以在[Subscan Essentials](https://github.com/itering/subscan-essentials){target=_blank}找到。
+[Subscan](https://moonbeam.subscan.io/){target=_blank} 是Moonbeam主要的Substrate API区块浏览器，它能够解析标准或自定义模块。举例而言，这个功能对展示关于质押、治理和EVM pallet（或是模块）非常有帮助。所有代码都是开源的，并且可以在[Subscan Essentials](https://github.com/subscan-explorer/subscan-essentials){target=_blank}找到。
 
-![Subscan Moonriver](/images/builders/get-started/explorers/explorers-3.png)
+![Subscan Moonbeam](/images/builders/get-started/explorers/explorers-3.png)
 
 ### Polkadot.js {: #polkadotjs }
 
 虽然Polkadot.js Apps不是功能齐全的区块浏览器，但是一个方便的选项，尤其是对于运行本地开发节点的用户，使其可以查看事件和查询交易哈希。Polkadot.js Apps使用WebSocket端点与网络进行交互。Polkadot.js Apps支持[Moonbeam](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank}、[Moonriver](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbase.moonbeam.network#/explorer){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}。
 
-![Polkadot.js Moonriver](/images/builders/get-started/explorers/explorers-4.png)
+![Polkadot.js Moonbeam](/images/builders/get-started/explorers/explorers-4.png)
 
 要将其连接到 Moonbeam 开发节点，您可以按照 [将Polkadot.js应用程序连接到本地Moonbeam节点](/builders/get-started/networks/moonbeam-dev/#connecting-polkadot-js-apps-to-a-local-moonbeam-node){target=_blank}部分的[开始使用 Moonbeam 开发节点](/builders/get-started/networks/moonbeam-dev/){target=_blank} 指南。默认端口为`9944`。
 

--- a/builders/get-started/explorers.md
+++ b/builders/get-started/explorers.md
@@ -17,7 +17,7 @@ Moonbeam现在提供两种不同的浏览器：一种用于查询以太坊API，
 
 ## 以太坊API {: #ethereum-api }
 
-### Moonscan {: #Moonscan } 
+### Moonscan {: #Moonscan }
 
 [Moonscan](https://moonscan.io/){target=_blank}是Moonbeam主要的以太坊API区块浏览器。Moonscan由Etherscan团队创建，为用户提供强大、直观且功能丰富的体验。除了全面的交易和区块数据，Moonscan还提供一系列的[数据和图表](https://moonbeam.moonscan.io/charts){target=_blank}，如平均Gas价格、日交易量和区块大小图表。
 
@@ -31,21 +31,7 @@ Moonscan其他功能如下：
 
 ![Moonriver Moonscan](/images/builders/get-started/explorers/explorers-1.png)
 
-### Blockscout {: #blockscout } 
-
-[Blockscout](https://blockscout.moonriver.moonbeam.network/){target=_blank}提供一个用户友好型的界面，让用户能够检查并确认在EVM区块链上的交易，包括Moonbeam。使用户能够搜寻交易、查看账户和余额，以及验证智能合约。更多信息请访问[文档网站](https://docs.blockscout.com/){target=_blank}。
-
-Blockscout还提供以下功能：
-
- - 开源开发，意味着所有的代码都对社群开源或是改进。您可以在[这里](https://github.com/blockscout/blockscout){target=_blank}找到代码
- - 实时交易追踪
- - 智能合约交互
- - [带有GraphQL的功能齐全的API](https://blockscout.moonriver.moonbeam.network/graphiql){target=_blank}，用户可以通过网页界面直接测试API调用
- - 支持ERC-20和ERC-721 Token，在友好型界面中列出所有能使用的Token合约
-
-![Blockscout Explorer](/images/builders/get-started/explorers/explorers-2.png)
-
-### Expedition {: #expedition } 
+### Expedition {: #expedition }
 
 以Moonbeam为主题的[Expedition](https://github.com/xops/expedition){target=_blank}浏览器版可以在[此链接](https://moonbeam-explorer.netlify.app/){target=_blank}找到。它是一个简单的JSON-RPC浏览器。
 
@@ -55,23 +41,23 @@ Blockscout还提供以下功能：
 
   2. 如果您想要连接至特定的PRC URL，选择**Add Custom Chain**，输入URL。例如：`http://localhost:9937`
 
-![Expedition Explorer](/images/builders/get-started/explorers/explorers-3.png)
+![Expedition Explorer](/images/builders/get-started/explorers/explorers-2.png)
 
-## Substrate API {: #substrate-api } 
+## Substrate API {: #substrate-api }
 
-### Subscan {: #subscan } 
+### Subscan {: #subscan }
 
 [Subscan](https://moonbeam.subscan.io/){target=_blank} 是Moonbeam主要的Substrate API区块浏览器，它能够解析标准或自定义模块。举例而言，这个功能对展示关于质押、治理和EVM pallet（或是模块）非常有帮助。所有代码都是开源的，并且可以在[Subscan Essentials](https://github.com/itering/subscan-essentials){target=_blank}找到。
 
-![Subscan Moonriver](/images/builders/get-started/explorers/explorers-4.png)
+![Subscan Moonriver](/images/builders/get-started/explorers/explorers-3.png)
 
-### Polkadot.js {: #polkadotjs } 
+### Polkadot.js {: #polkadotjs }
 
 虽然Polkadot.js Apps不是功能齐全的区块浏览器，但是一个方便的选项，尤其是对于运行本地开发节点的用户，使其可以查看事件和查询交易哈希。Polkadot.js Apps使用WebSocket端点与网络进行交互。Polkadot.js Apps支持[Moonbeam](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank}、[Moonriver](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbase.moonbeam.network#/explorer){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}。
 
-![Polkadot.js Moonriver](/images/builders/get-started/explorers/explorers-5.png)
+![Polkadot.js Moonriver](/images/builders/get-started/explorers/explorers-4.png)
 
 要将其连接到 Moonbeam 开发节点，您可以按照 [将Polkadot.js应用程序连接到本地Moonbeam节点](/builders/get-started/networks/moonbeam-dev/#connecting-polkadot-js-apps-to-a-local-moonbeam-node){target=_blank}部分的[开始使用 Moonbeam 开发节点](/builders/get-started/networks/moonbeam-dev/){target=_blank} 指南。默认端口为`9944`。
 
-![Polkadot.js Local Node](/images/builders/get-started/explorers/explorers-6.png)
+![Polkadot.js Local Node](/images/builders/get-started/explorers/explorers-5.png)
 

--- a/builders/get-started/networks/moonbase.md
+++ b/builders/get-started/networks/moonbase.md
@@ -12,7 +12,6 @@ description: Moonbeam测试网（Moonbase Alpha）是进入波卡（Polkadot）�
 您可以使用任意区块浏览器查看Moonbase Alpha：
 
  - **Ethereum API（等同于Etherscan）** —— [Moonscan](https://moonbase.moonscan.io/){target=_blank}
- - **带索引的Ethereum API** —— [Blockscout](https://moonbase-blockscout.testnet.moonbeam.network/){target=_blank}
  - **基于Ethereum API JSON-RPC** —— [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}
  - **Substrate API** —— [Subscan](https://moonbase.subscan.io/){target=_blank}或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}
 

--- a/builders/get-started/networks/moonbeam.md
+++ b/builders/get-started/networks/moonbeam.md
@@ -12,7 +12,6 @@ description: 学习如何通过RPC和WSS端点连接至Moonbeam，如何连接Me
 您可以使用以下浏览器来浏览Moonbeam：
 
  - **以太坊API（类似Etherscan）**—— [Moonscan](https://moonbeam.moonscan.io/){target=_blank}
- - **具有索引功能的以太坊API** —— [Blockscout](https://blockscout.moonbeam.network/){target=_blank}
  - **基于以太坊API JSON-RPC** —— [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonbeam){target=_blank}
  - **Substrate API** —— [Subscan](https://moonbeam.subscan.io/){target=_blank}或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank}
 

--- a/builders/get-started/networks/moonriver.md
+++ b/builders/get-started/networks/moonriver.md
@@ -12,7 +12,6 @@ description: 学习如何通过RPC和WSS端点连接到Moonriver网络 - Moonbea
 您可以使用以下区块链浏览器来浏览Moonriver:
 
  - **以太坊API(类似Etherscan)** — [Moonscan](https://moonriver.moonscan.io/){target=_blank}
- - **基于以太坊API和索引** — [Blockscout](https://blockscout.moonriver.moonbeam.network/){target=_blank}
  - **基于以太坊API JSON-RPC** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}
  - **基于Substrate API** — [Subscan](https://moonriver.subscan.io/)或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/explorer){target=_blank}
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -7,7 +7,7 @@ description: 学习如何运用Geth的Debug和Txpool API，以及OpenEthereum的
 
 ## 概览 {: #introduction }
 
-Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非标准RPC方法以获得交易处理的深度信息。作为Moonbeam为开发者提供无缝以太坊开发体验目标的其中一部分，Moonbeam支持部分非标准RPC方法。支持这些RPC方法是个重要的里程碑，因为如[The Graph](https://thegraph.com/){target=_blank}或[Blockscout](https://docs.blockscout.com/){target=_blank}等项目仰赖这些方法检索区块链数据。
+Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非标准RPC方法以获得交易处理的深度信息。作为Moonbeam为开发者提供无缝以太坊开发体验目标的其中一部分，Moonbeam支持部分非标准RPC方法。支持这些RPC方法是个重要的里程碑，因为如[The Graph](https://thegraph.com/){target=_blank}等项目仰赖这些方法检索区块链数据。
 
 想要使用支持的RPC方法，您需要运行一个追踪节点。与运行一个全节点略有不同，追踪节点使用一个不同的Docker镜像，名为`purestake/moonbeam-tracing`，运用其来实现追踪功能。同时，也需使用额外的标志来告诉节点需要支持哪个非标准功能。
 


### PR DESCRIPTION
### Description/Original PRs

This PR removes blockscout from the docs as we'll be shutting off the blockscout services for Moonbeam early October.
Original PR: https://github.com/moonbeam-foundation/moonbeam-docs/pull/751

