### PR TITLE
remove onFinality public endpoints

### DIFF
--- a/.snippets/text/builders/get-started/endpoints/moonbase.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbase.md
@@ -4,7 +4,6 @@
     |        Blast        |    <pre>```https://moonbase-alpha.public.blastapi.io```</pre>    |
     |       Dwellir       |        <pre>```https://moonbase-rpc.dwellir.com```</pre>         |
     | Moonbeam Foundation |    <pre>```https://rpc.api.moonbase.moonbeam.network```</pre>    |
-    |     OnFinality      | <pre>```https://moonbeam-alpha.api.onfinality.io/public```</pre> |
     |     UnitedBloc      |         <pre>```https://moonbase.unitedbloc.com```</pre>         |
 
 === "WSS"
@@ -13,7 +12,6 @@
     |        Blast        |     <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>      |
     |       Dwellir       |          <pre>```wss://moonbase-rpc.dwellir.com```</pre>          |
     | Moonbeam Foundation |     <pre>```wss://wss.api.moonbase.moonbeam.network```</pre>      |
-    |     OnFinality      | <pre>```wss://moonbeam-alpha.api.onfinality.io/public-ws```</pre> |
     |     UnitedBloc      |          <pre>```wss://moonbase.unitedbloc.com```</pre>           |
 
 #### 中继链 {: #relay-chain }

--- a/.snippets/text/builders/get-started/endpoints/moonbase.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbase.md
@@ -1,18 +1,18 @@
 === "HTTPS"
-    |       供应商        |                             RPC URL                              |
-    |:-------------------:|:----------------------------------------------------------------:|
-    |        Blast        |    <pre>```https://moonbase-alpha.public.blastapi.io```</pre>    |
-    |       Dwellir       |        <pre>```https://moonbase-rpc.dwellir.com```</pre>         |
-    | Moonbeam Foundation |    <pre>```https://rpc.api.moonbase.moonbeam.network```</pre>    |
-    |     UnitedBloc      |         <pre>```https://moonbase.unitedbloc.com```</pre>         |
+    |       供应商        |                          RPC URL                           |
+    |:-------------------:|:----------------------------------------------------------:|
+    |        Blast        | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> |
+    |       Dwellir       |     <pre>```https://moonbase-rpc.dwellir.com```</pre>      |
+    | Moonbeam Foundation | <pre>```https://rpc.api.moonbase.moonbeam.network```</pre> |
+    |     UnitedBloc      |      <pre>```https://moonbase.unitedbloc.com```</pre>      |
 
 === "WSS"
-    |       供应商        |                              RPC URL                              |
-    |:-------------------:|:-----------------------------------------------------------------:|
-    |        Blast        |     <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>      |
-    |       Dwellir       |          <pre>```wss://moonbase-rpc.dwellir.com```</pre>          |
-    | Moonbeam Foundation |     <pre>```wss://wss.api.moonbase.moonbeam.network```</pre>      |
-    |     UnitedBloc      |          <pre>```wss://moonbase.unitedbloc.com```</pre>           |
+    |       供应商        |                         RPC URL                          |
+    |:-------------------:|:--------------------------------------------------------:|
+    |        Blast        | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> |
+    |       Dwellir       |     <pre>```wss://moonbase-rpc.dwellir.com```</pre>      |
+    | Moonbeam Foundation | <pre>```wss://wss.api.moonbase.moonbeam.network```</pre> |
+    |     UnitedBloc      |      <pre>```wss://moonbase.unitedbloc.com```</pre>      |
 
 #### 中继链 {: #relay-chain }
 

--- a/.snippets/text/builders/get-started/endpoints/moonbeam.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbeam.md
@@ -4,7 +4,6 @@
     |     1RPC     |                             <pre>```https://1rpc.io/glmr```</pre>                             |
     |    Blast     |                     <pre>```https://moonbeam.public.blastapi.io```</pre>                      |
     |   Dwellir    |                       <pre>```https://moonbeam-rpc.dwellir.com```</pre>                       |
-    |  OnFinality  |                  <pre>```https://moonbeam.api.onfinality.io/public```</pre>                   |
     | POKT Network | <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
     |  UnitedBloc  |                       <pre>```https://moonbeam.unitedbloc.com```</pre>                        |
 
@@ -13,5 +12,4 @@
     |:----------:|:-----------------------------------------------------------:|
     |   Blast    |     <pre>```wss://moonbeam.public.blastapi.io```</pre>      |
     |  Dwellir   |       <pre>```wss://moonbeam-rpc.dwellir.com```</pre>       |
-    | OnFinality | <pre>```wss://moonbeam.api.onfinality.io/public-ws```</pre> |
     | UnitedBloc |       <pre>```wss://moonbeam.unitedbloc.com```</pre>        |

--- a/.snippets/text/builders/get-started/endpoints/moonbeam.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbeam.md
@@ -8,8 +8,8 @@
     |  UnitedBloc  |                       <pre>```https://moonbeam.unitedbloc.com```</pre>                        |
 
 === "WSS"
-    |   供应商   |                           RPC URL                           |
-    |:----------:|:-----------------------------------------------------------:|
-    |   Blast    |     <pre>```wss://moonbeam.public.blastapi.io```</pre>      |
-    |  Dwellir   |       <pre>```wss://moonbeam-rpc.dwellir.com```</pre>       |
-    | UnitedBloc |       <pre>```wss://moonbeam.unitedbloc.com```</pre>        |
+    |   供应商   |                      RPC URL                       |
+    |:----------:|:--------------------------------------------------:|
+    |   Blast    | <pre>```wss://moonbeam.public.blastapi.io```</pre> |
+    |  Dwellir   |  <pre>```wss://moonbeam-rpc.dwellir.com```</pre>   |
+    | UnitedBloc |   <pre>```wss://moonbeam.unitedbloc.com```</pre>   |

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -3,7 +3,6 @@
     |:------------:|:----------------------------------------------------------------------------------------------:|
     |    Blast     |                     <pre>```https://moonriver.public.blastapi.io```</pre>                      |
     |   Dwellir    |                       <pre>```https://moonriver-rpc.dwellir.com```</pre>                       |
-    |  OnFinality  |                  <pre>```https://moonriver.api.onfinality.io/public```</pre>                   |
     | POKT Network | <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
     |  UnitedBloc  |                       <pre>```https://moonriver.unitedbloc.com```</pre>                        |
 
@@ -12,5 +11,4 @@
     |:----------:|:------------------------------------------------------------:|
     |   Blast    |     <pre>```wss://moonriver.public.blastapi.io```</pre>      |
     |  Dwellir   |       <pre>```wss://moonriver-rpc.dwellir.com```</pre>       |
-    | OnFinality | <pre>```wss://moonriver.api.onfinality.io/public-ws```</pre> |
     | UnitedBloc |       <pre>```wss://moonriver.unitedbloc.com```</pre>        |

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -7,8 +7,8 @@
     |  UnitedBloc  |                       <pre>```https://moonriver.unitedbloc.com```</pre>                        |
 
 === "WSS"
-    |   供应商   |                           RPC URL                            |
-    |:----------:|:------------------------------------------------------------:|
-    |   Blast    |     <pre>```wss://moonriver.public.blastapi.io```</pre>      |
-    |  Dwellir   |       <pre>```wss://moonriver-rpc.dwellir.com```</pre>       |
-    | UnitedBloc |       <pre>```wss://moonriver.unitedbloc.com```</pre>        |
+    |   供应商   |                       RPC URL                       |
+    |:----------:|:---------------------------------------------------:|
+    |   Blast    | <pre>```wss://moonriver.public.blastapi.io```</pre> |
+    |  Dwellir   |  <pre>```wss://moonriver-rpc.dwellir.com```</pre>   |
+    | UnitedBloc |   <pre>```wss://moonriver.unitedbloc.com```</pre>   |

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -31,27 +31,27 @@ Moonbeam是波卡上完全兼容以太坊的智能合约平台。如此一来，
 
 === "Moonbeam"
 
-    |      变量       |                                                                                                       值                                                                                                       |
-    |:---------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                                               <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                                                |
+    |      变量       |                                                                         值                                                                          |
+    |:---------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                                                  <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                  |
     | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>
+    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>                                                  |
 
 === "Moonriver"
 
-    |      变量       |                                                                                                        值                                                                                                         |
-    |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                                                <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                                                 |
+    |      变量       |                                                                          值                                                                           |
+    |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                                                  <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                   |
     | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre>
+    | Public WSS URLs |                                                  <pre>```wss://moonriver.public.blastapi.io```</pre>                                                  |
 
 === "Moonbase Alpha"
 
-    |      变量       |                                                                                      值                                                                                      |
-    |:---------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                                                               |
+    |      变量       |                                                      值                                                      |
+    |:---------------:|:------------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                               |
     | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre>  <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
-    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>  <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
+    | Public WSS URLs |  <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>  <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
 
 === "Moonbeam开发节点"
 

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -34,24 +34,24 @@ Moonbeam是波卡上完全兼容以太坊的智能合约平台。如此一来，
     |      变量       |                                                                                                       值                                                                                                       |
     |:---------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                               <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                                                |
-    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre> <pre>```https://moonbeam.api.onfinality.io/public```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre> <pre>```wss://moonbeam.api.onfinality.io/public-ws```</pre>                                                 |
+    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
+    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>
 
 === "Moonriver"
 
     |      变量       |                                                                                                        值                                                                                                         |
     |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                                <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                                                 |
-    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre> <pre>```https://moonriver.api.onfinality.io/public```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre> <pre>```wss://moonriver.api.onfinality.io/public-ws```</pre>                                                  |
+    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
+    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre>
 
 === "Moonbase Alpha"
 
     |      变量       |                                                                                      值                                                                                      |
     |:---------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                                                               |
-    | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> <pre>```https://moonbeam-alpha.api.onfinality.io/public```</pre> <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
-    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> <pre>```wss://moonbeam-alpha.api.onfinality.io/public-ws```</pre> <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
+    | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre>  <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
+    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>  <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
 
 === "Moonbeam开发节点"
 


### PR DESCRIPTION
### Description/Original PRs

Removes OnFinality public endpoints from the endpoints page. OnFinality private endpoints and paid endpoints are not impacted and remain unchanged. For more information, please see: https://forum.moonbeam.network/t/proposal-mb19-mr14-onfinality-high-performance-public-infrastructure-transition-project/1303

### Checklist

- [ ] If this requires removing old images from the `moonbeam-docs` repo, I have created a corresponding PR
- [ ] If this requires adding/updating/deleting redirects, I have created a corresponding PR in the `moonbeam-mkdocs` repo
- [ ] If this requires removing old variables from the `moonbeam-docs` repo, I have created a corresponding PR

### Corresponding PRs
 https://github.com/moonbeam-foundation/moonbeam-docs/pull/776