### PR TITLE
use termynal snippets on moonbeam dev node page

### DIFF
--- a/builders/build/substrate-api/py-substrate-interface.md
+++ b/builders/build/substrate-api/py-substrate-interface.md
@@ -279,7 +279,7 @@ keypair = Keypair.create_from_private_key(privatekey, crypto_type=KeypairType.EC
 # Form a transaction call
 call = ws_provider.compose_call(
     call_module="Balances",
-    call_function="transfer",
+    call_function="transfer_allow_death",
     call_params={
         "dest": "0x44236223aB4291b93EEd10E4B511B37a398DEE55",
         "value": 1 * 10**18,
@@ -317,7 +317,7 @@ try:
     # Construct a transaction call
     call = ws_provider.compose_call(
         call_module="Balances",
-        call_function="transfer",
+        call_function="transfer_allow_death",
         call_params={
             "dest": "0x44236223aB4291b93EEd10E4B511B37a398DEE55",
             "value": 1 * 10**18,
@@ -367,7 +367,7 @@ try:
     # Construct the same transaction call that was signed
     call = ws_provider.compose_call(
         call_module="Balances",
-        call_function="transfer",
+        call_function="transfer_allow_death",
         call_params={
             "dest": "0x44236223aB4291b93EEd10E4B511B37a398DEE55",
             "value": 1 * 10**18,
@@ -375,12 +375,12 @@ try:
     )
 
     # Construct the signed extrinsic with the generated signature
-    extrinsic = substrate.create_signed_extrinsic(
+    extrinsic = ws_provider.create_signed_extrinsic(
         call=call, keypair=keypair, signature=signature
     )
 
     # Submit the signed extrinsic
-    result = substrate.submit_extrinsic(extrinsic=extrinsic)
+    result = ws_provider.submit_extrinsic(extrinsic=extrinsic)
 
     # Print the execution result
     print(result.extrinsic_hash)

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -34,7 +34,7 @@ Moonbeam开发节点是您自己的个人开发环境，用于在Moonbeam上构�
 
     控制台日志的结尾应如下所示：
 
-    ![Docker - imaged pulled](/images/builders/get-started/networks/moonbeam-dev/moonbeam-dev-1.png)
+    --8<-- 'code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md'
 
 2. 通过运行以下Docker命令启动Moonbeam开发节点，该命令将以即时封装模式启动节点以进行本地测试，以便在收到交易时立即创建区块：
 
@@ -67,7 +67,7 @@ Moonbeam开发节点是您自己的个人开发环境，用于在Moonbeam上构�
 
 如果节点已经启动，您将看到显示区块待创建的空闲状态界面：
 
-![Docker - output shows blocks being produced](/images/builders/get-started/networks/moonbeam-dev/moonbeam-dev-2.png)
+--8<-- 'code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md'
 
 您可点击常用[标志](#node-flags)及[选项](#node-options)来查阅更多用于示例的标志及选项。如果要查看所有标志、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
 
@@ -130,7 +130,7 @@ moonbeamfoundation/moonbeam \
 
     构建输出的末尾应如下所示：
 
-    ![End of build output](/images/builders/get-started/networks/moonbeam-dev/moonbeam-dev-3.png)
+    --8<-- 'code/builders/get-started/networks/moonbeam-dev/terminal/compile.md'
 
 !!! 注意事项
     初始构建将会需要一些时间。取决于您的硬件设备，构建过程大约需要30分钟。
@@ -146,7 +146,7 @@ moonbeamfoundation/moonbeam \
 
 您将看到显示区块待创建的空闲状态界面：
 
-![Output shows blocks being produced](/images/builders/get-started/networks/moonbeam-dev/moonbeam-dev-4.png)
+--8<-- 'code/builders/get-started/networks/moonbeam-dev/terminal/run-binary.md'
 
 您可点击常用[标志](#node-flags)及[选项](#node-options)来查阅更多用于示例的标志及选项。如果要查看所有标志、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
 


### PR DESCRIPTION
### Description/Original PRs

Use the termynal code snippets here! And this PR also includes minor change to the py substrate interface code snippets

Original PRs:
- https://github.com/moonbeam-foundation/moonbeam-docs/pull/842/files
- https://github.com/moonbeam-foundation/moonbeam-docs/pull/843/files

### Checklist

- [x] If this requires removing old images from the `moonbeam-docs` repo, I have created a corresponding PR

### Corresponding PRs

https://github.com/moonbeam-foundation/moonbeam-docs/pull/844
https://github.com/papermoonio/moonbeam-mkdocs/pull/158