### PR TITLE
Refresh Hyperlane Links

### DIFF
--- a/builders/interoperability/protocols/hyperlane.md
+++ b/builders/interoperability/protocols/hyperlane.md
@@ -9,7 +9,7 @@ description: 了解用于跨链资产转移的GMP协议Hyperlane，以及如何�
 
 [Hyperlane](https://hyperlane.xyz){target=\_blank}是Web3的一个安全模块化的跨链通信协议，能够使dApp用户与任何资产或应用在任何互连的链上一键式交互。该协议支持通用资产传输以及自定义跨链通信。
 
-Hyperlane使用一个称为[主权共识](https://docs.hyperlane.xyz/hyperlane-docs-1/protocol/security/sovereign-consensus){target=\_blank}的方式，允许开发者通过配置该方式来跨链发送消息和验证消息。Hyperlane由验证人、中继器和瞭望塔（watchtowers）组成。验证人将监视并确认跨链消息。中继器支出gas，跨链发送消息。瞭望塔检查确保验证人是善意的参与者，从而保证协议的安全性。如需了解更多，请查看技术栈图及其他们的[协议文档](https://docs.hyperlane.xyz/hyperlane-docs-1/protocol/overview){target=\_blank}。
+Hyperlane使用一个称为[主权共识](https://docs.hyperlane.xyz/docs/protocol/ISM/modular-security){target=\_blank}的方式，允许开发者通过配置该方式来跨链发送消息和验证消息。Hyperlane由验证人、中继器和瞭望塔（watchtowers）组成。验证人将监视并确认跨链消息。中继器支出gas，跨链发送消息。瞭望塔检查确保验证人是善意的参与者，从而保证协议的安全性。如需了解更多，请查看技术栈图及其他们的[协议文档](https://docs.hyperlane.xyz/docs/protocol/protocol-overview){target=\_blank}。
 
 ![Hyperlane Technology Stack diagram](/images/builders/interoperability/protocols/hyperlane/hyperlane-1.webp)
 
@@ -21,15 +21,15 @@ Hyperlane API为开发Web3应用提供了丰富的套件，确保开发者拥有
 
 开始使用Hyperlane构建跨链应用程序可能所需的资源：
 
-- **[开发者文档](https://docs.hyperlane.xyz/hyperlane-docs-1/introduction/readme){target=\_blank}** —— 技术性指南
+- **[开发者文档](https://docs.hyperlane.xyz/docs/intro){target=\_blank}** —— 技术性指南
 - **[Hyperlane浏览器](https://explorer.hyperlane.xyz/){target=\_blank}** —— 追踪跨链传递
 
 ## 合约 {: #contracts }
 
 查看部署至Moonbeam的Hyperlane合约列表，以及通过Hyperlane连接至Moonbeam的网络。
 
-- **主网合约** - [Moonbeam](https://docs.hyperlane.xyz/hyperlane-docs-1/developers-faq-and-troubleshooting/addresses#mainnet){target=\_blank}
+- **主网合约** - [Moonbeam](https://docs.hyperlane.xyz/docs/reference/contract-addresses){target=\_blank}
 
-- **测试网合约** - [Moonbase Alpha](https://docs.hyperlane.xyz/hyperlane-docs-1/developers-faq-and-troubleshooting/addresses#testnet2){target=\_blank}
+- **测试网合约** - [Moonbase Alpha](https://docs.hyperlane.xyz/docs/reference/contract-addresses){target=\_blank}
 
 --8<-- 'text/_disclaimers/third-party-content.md'


### PR DESCRIPTION
### Description/Original PRs

Refreshes Hyperlane Links
Goes with https://github.com/moonbeam-foundation/moonbeam-docs/pull/859

### Checklist

- [ ] If this requires removing old images from the `moonbeam-docs` repo, I have created a corresponding PR
- [ ] If this requires adding/updating/deleting redirects, I have created a corresponding PR in the `moonbeam-mkdocs` repo
- [ ] If this requires removing old variables from the `moonbeam-docs` repo, I have created a corresponding PR

### Corresponding PRs

Please link to any additional corresponding PRs here.
