### PR TITLE
Frontier Link Updates

### DIFF
--- a/.snippets/text/builders/build/canonical-contracts/eth-mainnet.md
+++ b/.snippets/text/builders/build/canonical-contracts/eth-mainnet.md
@@ -10,4 +10,4 @@
 |                  [BN128Add](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128add){target=\_blank}                   | 0x0000000000000000000000000000000000000006 |
 |                  [BN128Mul](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128mul){target=\_blank}                   | 0x0000000000000000000000000000000000000007 |
 |              [BN128Pairing](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128pairing){target=\_blank}               | 0x0000000000000000000000000000000000000008 |
-|   [Blake2](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}    | 0x0000000000000000000000000000000000000009 |
+|   [Blake2](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}    | 0x0000000000000000000000000000000000000009 |

--- a/.snippets/text/builders/build/canonical-contracts/eth-mainnet.md
+++ b/.snippets/text/builders/build/canonical-contracts/eth-mainnet.md
@@ -1,7 +1,7 @@
 ### 以太坊主网预编译 {: #ethereum-mainnet-precompiles }
 
-|                                                             合约                                                              |                    地址                    |
-|:-----------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
+|                                                              合约                                                              |                    地址                    |
+|:------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
 |  [ECRECOVER](/builders/build/canonical-contracts/precompiles/eth-mainnet/#verify-signatures-with-ecrecover/){target=\_blank}   | 0x0000000000000000000000000000000000000001 |
 |          [SHA256](/builders/build/canonical-contracts/precompiles/eth-mainnet/#hashing-with-sha256/){target=\_blank}           | 0x0000000000000000000000000000000000000002 |
 |       [RIPEMD160](/builders/build/canonical-contracts/precompiles/eth-mainnet/#hashing-with-ripemd-160/){target=\_blank}       | 0x0000000000000000000000000000000000000003 |
@@ -10,4 +10,4 @@
 |                  [BN128Add](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128add){target=\_blank}                   | 0x0000000000000000000000000000000000000006 |
 |                  [BN128Mul](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128mul){target=\_blank}                   | 0x0000000000000000000000000000000000000007 |
 |              [BN128Pairing](/builders/pallets-precompiles/precompiles/eth-mainnet/#bn128pairing){target=\_blank}               | 0x0000000000000000000000000000000000000008 |
-|   [Blake2](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}    | 0x0000000000000000000000000000000000000009 |
+|  [Blake2](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}   | 0x0000000000000000000000000000000000000009 |

--- a/.snippets/text/builders/build/canonical-contracts/non-specific.md
+++ b/.snippets/text/builders/build/canonical-contracts/non-specific.md
@@ -3,5 +3,5 @@
 |                                                                      合约                                                                       |                    地址                    |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
 |                  [SHA3FIPS256](/builders/pallets-precompiles/precompiles/eth-mainnet/#hashing-with-sha3fips256){target=\_blank}                  | 0x0000000000000000000000000000000000000400 |
-|          [Dispatch](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_dispatch/struct.Dispatch.html){target=\_blank}          | 0x0000000000000000000000000000000000000401 |
-| [ECRecoverPublicKey](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_simple/struct.ECRecoverPublicKey.html){target=\_blank} | 0x0000000000000000000000000000000000000402 |
+|          [Dispatch](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_dispatch/struct.Dispatch.html){target=\_blank}          | 0x0000000000000000000000000000000000000401 |
+| [ECRecoverPublicKey](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_simple/struct.ECRecoverPublicKey.html){target=\_blank} | 0x0000000000000000000000000000000000000402 |

--- a/.snippets/text/builders/build/canonical-contracts/non-specific.md
+++ b/.snippets/text/builders/build/canonical-contracts/non-specific.md
@@ -1,7 +1,7 @@
 ### 非Moonbeam特定或以太坊预编译 {: #non-moonbeam-specific-nor-ethereum-precompiles }
 
-|                                                                      合约                                                                       |                    地址                    |
-|:-----------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
-|                  [SHA3FIPS256](/builders/pallets-precompiles/precompiles/eth-mainnet/#hashing-with-sha3fips256){target=\_blank}                  | 0x0000000000000000000000000000000000000400 |
+|                                                                        合约                                                                        |                    地址                    |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
+|                   [SHA3FIPS256](/builders/pallets-precompiles/precompiles/eth-mainnet/#hashing-with-sha3fips256){target=\_blank}                   | 0x0000000000000000000000000000000000000400 |
 |          [Dispatch](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_dispatch/struct.Dispatch.html){target=\_blank}          | 0x0000000000000000000000000000000000000401 |
 | [ECRecoverPublicKey](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_simple/struct.ECRecoverPublicKey.html){target=\_blank} | 0x0000000000000000000000000000000000000402 |

--- a/builders/build/eth-api/pubsub.md
+++ b/builders/build/eth-api/pubsub.md
@@ -117,4 +117,4 @@ EventSignature = keccak256(Transfer(address,address,uint256))
 ![Subscribe to syncing response](/images/builders/build/eth-api/pubsub/pubsub-7.webp)
 
 !!! 注意事项
-    [Frontier](https://github.com/paritytech/frontier){target=\_blank}的发布/订阅功能目前还在开发中。在此版本中，用户可以订阅特定的事件类型，但可能仍存在一些限制。
+    [Frontier](https://github.com/polkadot-evm/frontier){target=\_blank}的发布/订阅功能目前还在开发中。在此版本中，用户可以订阅特定的事件类型，但可能仍存在一些限制。

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -24,7 +24,7 @@ description: Moonbeam和Moonriver上历史更新概览，包含应用于Moonbeam
 |   Moonriver    |   RT49   |  RT600   |   0 - 455106   |
 | Moonbase Alpha |   RT40   |  RT600   |   0 - 675175   |
 
-关于更多信息，您可以查看[GitHub上的相关Frontier PR](https://github.com/paritytech/frontier/pull/465){target=\_blank}。
+关于更多信息，您可以查看[GitHub上的相关Frontier PR](https://github.com/polkadot-evm/frontier/pull/465){target=\_blank}。
 
 ***
 
@@ -55,7 +55,7 @@ Moonbeam配置为将保留账户最低存款（Existential Deposit）设置为0�
 |   Moonriver    |   RT49   |  RT1001  |  0 - 1052241   |
 | Moonbase Alpha |   RT40   |  RT1001  |  0 - 1285915   |
 
-关于更多信息，您可以在Github上查看[相关Frontier PR](https://github.com/paritytech/frontier/pull/509){target=\_blank}以及有关的[Substrate PR](https://github.com/paritytech/substrate/issues/10117){target=\_blank}。
+关于更多信息，您可以在Github上查看[相关Frontier PR](https://github.com/polkadot-evm/frontier/pull/509){target=\_blank}以及有关的[Substrate PR](https://github.com/paritytech/substrate/issues/10117){target=\_blank}。
 
 ***
 
@@ -158,7 +158,7 @@ EIP-2612和以太坊区块以秒为单位处理时间戳，然而Moonbeam采用�
 |:--------------:|:--------:|:--------:|:-----------------:|
 | Moonbase Alpha |  RT1200  |  RT1201  | 1648994 - 1679618 |
 
-关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/paritytech/frontier/pull/570){target=\_blank}。
+关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/polkadot-evm/frontier/pull/570){target=\_blank}。
 
 ***
 
@@ -264,7 +264,7 @@ EIP-2612和以太坊区块以秒为单位处理时间戳，然而Moonbeam采用�
 
 被复制的交易属于第一个区块。因此，在Moonriver上的交易属于区块2077599，而在Moonbase Alpha上受影响的交易属于2285347。
 
-关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/paritytech/frontier/pull/638){target=\_blank}。
+关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/polkadot-evm/frontier/pull/638){target=\_blank}。
 
 ***
 
@@ -280,7 +280,7 @@ EIP-2612和以太坊区块以秒为单位处理时间戳，然而Moonbeam采用�
 |   Moonriver    |  RT1701  |  RT1802  | 2281723 - 2616189 |
 | Moonbase Alpha |  RT1700  |  RT1802  | 2529736 - 2879402 |
 
-关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/paritytech/frontier/pull/935){target=\_blank}。
+关于更多信息，您可以在[GitHub上查看相关Frontier PR](https://github.com/polkadot-evm/frontier/pull/935){target=\_blank}。
 
 ***
 

--- a/builders/build/substrate-api/overview.md
+++ b/builders/build/substrate-api/overview.md
@@ -25,7 +25,7 @@ Pallet用于制定和扩展基于Substrate区块链的功能。这些可以被�
 - **[Assets Pallet](https://crates.io/crates/pallet-assets){target=\_blank}** — 处理链上同质化资产的创建和管理
 - **Consensus Pallets** — 这些pallet为区块生产提供不同的共识机制，例如[AURA](https://crates.io/crates/pallet-aura){target=\_blank}和[BABE](https://crates.io/crates/pallet-babe){target=\_blank}
 - **Governance Pallets** — 这些pallet（例如[Referenda](https://crates.io/crates/pallet-referenda){target=\_blank}和[Collective](https://crates.io/crates/pallet-collective){target=\_blank}）提供链上治理机制
-- **[Frontier Pallets](https://paritytech.github.io/frontier/){target=\_blank}** — 以太坊兼容层pallet，允许基于Substrate的区块链与Moonbeam团队首创的基于以太坊的应用程序交互，包括[EVM Pallet](https://crates.io/crates/pallet-evm){target=\_blank}
+- **[Frontier Pallets](https://polkadot-evm.github.io/frontier/){target=\_blank}** — 以太坊兼容层pallet，允许基于Substrate的区块链与Moonbeam团队首创的基于以太坊的应用程序交互，包括[EVM Pallet](https://crates.io/crates/pallet-evm){target=\_blank}
 - **[Parachain Staking Pallet](/builders/pallets-precompiles/pallets/staking/){target=\_blank}** — Moonbeam创建的pallet，支持委托权益证明（DPoS）系统
 
 除了Polkadot Substrate提供的标准pallet之外，开发者还可以[创建自己的Pallet](https://docs.substrate.io/tutorials/collectibles-workshop/03-create-pallet/){target=\_blank}为自己的区块链添加自定义功能。

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -15,7 +15,7 @@ Moonbeam开发节点是您自己的个人开发环境，用于在Moonbeam上构�
 如果您完整地遵循本教程操作，您将拥有一个在本地环境中运行的Moonbeam开发节点，其中包含10个[预注资的账户](#pre-funded-development-accounts)。
 
 !!! 注意事项
-    本教程使用[Moonbase Alpha](https://github.com/moonbeam-foundation/moonbeam/releases/tag/{{ networks.development.build_tag }}){target=\_blank}的{{ networks.development.build_tag }}标签创建。为实现与以太坊的全面兼容，基于Substrate的Moonbeam平台和[Frontier](https://github.com/paritytech/frontier){target=\_blank}组件正处于积极开发阶段。
+    本教程使用[Moonbase Alpha](https://github.com/moonbeam-foundation/moonbeam/releases/tag/{{ networks.development.build_tag }}){target=\_blank}的{{ networks.development.build_tag }}标签创建。为实现与以太坊的全面兼容，基于Substrate的Moonbeam平台和[Frontier](https://github.com/polkadot-evm/frontier){target=\_blank}组件正处于积极开发阶段。
     --8<-- 'text/_common/assumes-mac-or-ubuntu-env.md'
 
 ## 启动Moonbeam开发节点 {: #spin-up-a-node }

--- a/builders/pallets-precompiles/precompiles/overview.md
+++ b/builders/pallets-precompiles/precompiles/overview.md
@@ -9,7 +9,7 @@ description: Moonbeam上可用Solidity预编译的概述。预编译使您能够
 
 在Moonbeam上，预编译合约是拥有以太坊格式地址的原生Substrate代码，与其他智能合约一样能够可以使用以太坊API进行调用。预编译允许您直接调用Substrate runtime，其通常在Moonbeam的以太坊这端无法访问。
 
-用于实施预编译的Substrate代码可以在[EVM pallet](/learn/features/eth-compatibility/#evm-pallet){target=\_blank}中找到。EVM pallet包含了[以太坊上的标准预编译以及一些不特定于以太坊的预编译](https://github.com/paritytech/frontier/tree/master/frame/evm/precompile){target=\_blank}。它也包含了通过通用[`Precompiles` 特征](https://paritytech.github.io/frontier/rustdocs/pallet_evm/trait.Precompile.html){target=\_blank}创建和执行自定义预编译的能力。目前已经创建了好几个特定于Moonbeam的自定义预编译，您可以在[Moonbeam代码库](https://github.com/moonbeam-foundation/moonbeam/tree/master/precompiles){target=\_blank}中找到。
+用于实施预编译的Substrate代码可以在[EVM pallet](/learn/features/eth-compatibility/#evm-pallet){target=\_blank}中找到。EVM pallet包含了[以太坊上的标准预编译以及一些不特定于以太坊的预编译](https://github.com/polkadot-evm/frontier/tree/master/frame/evm/precompile){target=\_blank}。它也包含了通过通用[`Precompiles` 特征](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm/trait.Precompile.html){target=\_blank}创建和执行自定义预编译的能力。目前已经创建了好几个特定于Moonbeam的自定义预编译，您可以在[Moonbeam代码库](https://github.com/moonbeam-foundation/moonbeam/tree/master/precompiles){target=\_blank}中找到。
 
 以太坊预编译合约包含了带有大量计算的复杂功能，例如哈希和加密等。Moonbeam上自定义预编译合约提供对基于Substrate功能的访问，例如质押、治理、XCM相关函数等。
 

--- a/learn/features/eth-compatibility.md
+++ b/learn/features/eth-compatibility.md
@@ -26,10 +26,10 @@ Moonbeam支持以下几点：
 
 ## Frontier {: #frontier }
 
-[Frontier](https://paritytech.github.io/frontier/){target=\_blank} 是Substrate的以太坊兼容层。Frontier的目标是让标准的以太坊DApp无需修改即可在基于Substrate的链上运行。Frontier通过提供一些可以插入Substrate运行时（runtime）的Substrate pallet使这成为可能。以下pallet可以根据需要单独使用，也可以根据链所需的功能一起使用：
+[Frontier](https://polkadot-evm.github.io/frontier/){target=\_blank} 是Substrate的以太坊兼容层。Frontier的目标是让标准的以太坊DApp无需修改即可在基于Substrate的链上运行。Frontier通过提供一些可以插入Substrate运行时（runtime）的Substrate pallet使这成为可能。以下pallet可以根据需要单独使用，也可以根据链所需的功能一起使用：
 
-- **[EVM pallet](#evm-pallet){target=\_blank}** - 处理EVM执行
-- **[Ethereum pallet](#ethereum-pallet){target=\_blank}** - 负责存储区块数据并提供RPC兼容性
+- **[EVM pallet](#evm-pallet)** - 处理EVM执行
+- **[Ethereum pallet](#ethereum-pallet)** - 负责存储区块数据并提供RPC兼容性
 - **基础费用pallet** - 添加对EIP-1559交易的支持并处理基本费用计算
 - **动态费用pallet** - 计算动态最低gas价格
 
@@ -37,7 +37,7 @@ Moonbeam使用EVM和Ethereum pallet来实现完全的以太坊兼容。Moonbeam�
 
 ### EVM Pallet {: #evm-pallet }
 
-[EVM pallet](https://paritytech.github.io/frontier/frame/evm.html){target=\_blank} 实现了沙盒虚拟堆栈机并使用[SputnikVM](https://github.com/rust-blockchain/evm){target=\_blank}作为底层EVM引擎。
+[EVM pallet](https://polkadot-evm.github.io/frontier/frame/evm.html){target=\_blank} 实现了沙盒虚拟堆栈机并使用[SputnikVM](https://github.com/rust-blockchain/evm){target=\_blank}作为底层EVM引擎。
 
 EVM执行以太坊智能合约字节码，其中通常使用Solidity等语言编写，然后将其编译为EVM字节码。EVM pallet的目标是在Substrate运行时模拟在以太坊上执行智能合约的功能。因此，它允许现有的EVM代码在基于Substrate的区块链中执行。
 
@@ -49,23 +49,23 @@ EVM内部是标准的H160以太坊式账户，并且它们具有关联数据，�
 
 如果区块链不需要以太坊模拟，只需要EVM执行，Substrate会完全使用其账户模型并代表EVM账户签署交易。 然而，在这个模型中，以太坊RPC不可用，DApps 必须使用Substrate API编写它们的前端。
 
-与以太坊相比，EVM pallet应该产生几乎相同的执行结果，例如gas费用和余额变化。但是，仍然存在一些差异。有关详细信息，请参阅Frontier EVM Pallet文档的[EVM module vs Ethereum network](https://paritytech.github.io/frontier/frame/evm.html#evm-module-vs-ethereum-network){target=\_blank}部分。
+与以太坊相比，EVM pallet应该产生几乎相同的执行结果，例如gas费用和余额变化。但是，仍然存在一些差异。有关详细信息，请参阅Frontier EVM Pallet文档的[EVM module vs Ethereum network](https://polkadot-evm.github.io/frontier/frame/evm.html#evm-module-vs-ethereum-network){target=\_blank}部分。
 
-还有一些[预编译](https://github.com/paritytech/frontier/tree/4c05c2b09e71336d6b11207e6d12e486b4d2705c#evm-pallet-precompiles){target=\_blank}可以与EVM pallet一起使用，扩展EVM的功能。Moonbeam使用以下EVM预编译：
+还有一些[预编译](https://github.com/polkadot-evm/frontier/tree/4c05c2b09e71336d6b11207e6d12e486b4d2705c#evm-pallet-precompiles){target=\_blank}可以与EVM pallet一起使用，扩展EVM的功能。Moonbeam使用以下EVM预编译：
 
-- **[pallet-evm-precompile-simple](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_simple/){target=\_blank}** - 包括五个基本预编译: ECRecover, ECRecoverPublicKey, Identity, RIPEMD160, SHA256
-- **[pallet-evm-precompile-blake2](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}** - 包括 BLAKE2 预编译
-- **[pallet-evm-precompile-bn128](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_bn128/index.html){target=\_blank}** - 包括三个 BN128 预编译: BN128Add、BN128Mul和BN128Pairing
-- **[pallet-evm-precompile-modexp](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_modexp/struct.Modexp.html){target=\_blank}** - 包括模幂预编译
-- **[pallet-evm-precompile-sha3fips](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_sha3fips/struct.Sha3FIPS256.html){target=\_blank}** - 包括标准SHA3预编译
-- **[pallet-evm-precompile-dispatch](https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_dispatch/struct.Dispatch.html){target=\_blank}** - 包括调度（dispatch）预编译
+- **[pallet-evm-precompile-simple](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_simple/){target=\_blank}** - 包括五个基本预编译: ECRecover, ECRecoverPublicKey, Identity, RIPEMD160, SHA256
+- **[pallet-evm-precompile-blake2](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html){target=\_blank}** - 包括 BLAKE2 预编译
+- **[pallet-evm-precompile-bn128](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_bn128/index.html){target=\_blank}** - 包括三个 BN128 预编译: BN128Add、BN128Mul和BN128Pairing
+- **[pallet-evm-precompile-modexp](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_modexp/struct.Modexp.html){target=\_blank}** - 包括模幂预编译
+- **[pallet-evm-precompile-sha3fips](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_sha3fips/struct.Sha3FIPS256.html){target=\_blank}** - 包括标准SHA3预编译
+- **[pallet-evm-precompile-dispatch](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_dispatch/struct.Dispatch.html){target=\_blank}** - 包括调度（dispatch）预编译
 
 您可以在[以太网主网预编译合约](/builders/pallets-precompiles/precompiles/eth-mainnet){target=\_blank}页面上找到大部分这些预编译的概述。
 
 ### Ethereum Pallet {: #ethereum-pallet}
 
-[Ethereum pallet](https://paritytech.github.io/frontier/frame/ethereum.html){target=\_blank} 负责处理区块，交易收据和状态。 它通过存储以太坊风格的区块和其在Substrate运行时中关联的交易哈希来实现向Moonbeam发送和接收以太坊格式的数据。
+[Ethereum pallet](https://polkadot-evm.github.io/frontier/frame/ethereum.html){target=\_blank} 负责处理区块，交易收据和状态。 它通过存储以太坊风格的区块和其在Substrate运行时中关联的交易哈希来实现向Moonbeam发送和接收以太坊格式的数据。
 
 当用户提交一个原始以太坊交易时，它会通过pallet Ethereum的`transact` extrinsic转换为一个Substrate交易。使用Ethereum pallet作为EVM pallet的唯一执行者，强制所有数据以与以太坊兼容的方式进行存储和交易。这使得由Etherscan构建的[Moonscan](/builders/get-started/explorers#moonscan){target=\_blank}等区块浏览器能够索引区块数据。
 
-除了支持以太坊风格的数据外，以Ethereum pallet与[RPC模块](https://github.com/paritytech/frontier/tree/master/client/rpc){target=\_blank}相结合还提供了RPC支持。这使得可以使用[基本的以太坊JSON-RPC方法](/builders/get-started/eth-compare/rpc-support#basic-ethereum-json-rpc-methods){target=\_blank}，最终允许现有的以太坊DApps以最少的更改部署到Moonbeam。
+除了支持以太坊风格的数据外，以Ethereum pallet与[RPC模块](https://github.com/polkadot-evm/frontier/tree/master/client/rpc){target=\_blank}相结合还提供了RPC支持。这使得可以使用[基本的以太坊JSON-RPC方法](/builders/get-started/eth-compare/rpc-support#basic-ethereum-json-rpc-methods){target=\_blank}，最终允许现有的以太坊DApps以最少的更改部署到Moonbeam。


### PR DESCRIPTION
### Description/Original PRs

Parity changed the name of one of the github pages so some links were 404ing. The confusing part is that not All page links need to be changed, for example: https://paritytech.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html needs to be changed to https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_blake2/struct.Blake2F.html but

https://paritytech.github.io/polkadot-sdk/master/frame_support/struct.Blake2_128Concat.html is still valid. So when reviewing this you'll notice that not every paritytech link was changed.

Goes with https://github.com/moonbeam-foundation/moonbeam-docs/pull/861

### Checklist

- [ ] If this requires removing old images from the `moonbeam-docs` repo, I have created a corresponding PR
- [ ] If this requires adding/updating/deleting redirects, I have created a corresponding PR in the `moonbeam-mkdocs` repo
- [ ] If this requires removing old variables from the `moonbeam-docs` repo, I have created a corresponding PR

### Corresponding PRs

Please link to any additional corresponding PRs here.
